### PR TITLE
Fix type hint for SearchResultObject.data

### DIFF
--- a/stripe/_search_result_object.py
+++ b/stripe/_search_result_object.py
@@ -26,7 +26,7 @@ T = TypeVar("T", bound=StripeObject)
 
 class SearchResultObject(StripeObject, Generic[T]):
     OBJECT_NAME = "search_result"
-    data: List[StripeObject]
+    data: List[T]
     has_more: bool
     next_page: str
 


### PR DESCRIPTION
I think this is correct, a comment in the same file even mentions that `data` is of type `list[T]`.